### PR TITLE
Bump elixir version to v1.3, and update syntax

### DIFF
--- a/lib/leex_yecc_tutorial.ex
+++ b/lib/leex_yecc_tutorial.ex
@@ -1,16 +1,16 @@
 defmodule LeexYeccTutorial do
- def lex(s) when is_binary(s), do: s |> to_char_list |> lex
+ def lex(s) when is_binary(s), do: s |> to_charlist() |> lex()
  def lex(s) do
    {:ok, tokens, _} = :number_lexer.string(s)
    tokens
  end
 
- def parse(s) when is_binary(s), do: s |> to_char_list |> parse
+ def parse(s) when is_binary(s), do: s |> to_charlist() |> parse()
  def parse(s) do
    {:ok, tokens, _} = :number_lexer.string(s)
-   :number_parser.parse(tokens) |> complete_parse
+   :number_parser.parse(tokens) |> complete_parse()
  end
 
  def complete_parse({:ok, ast}), do: ast
- def complete_parse({:error, {line, _, message}}), do: {:error, ["Line: #{line} "] ++ message |> Enum.join}
+ def complete_parse({:error, {line, _, message}}), do: {:error, ["Line: #{line} "] ++ message |> Enum.join()}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,10 +4,10 @@ defmodule LeexYeccTutorial.Mixfile do
   def project do
     [app: :leex_yecc_tutorial,
      version: "0.0.1",
-     elixir: "~> 1.2",
+     elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Fix warnings for syntax that has been deprecated in more recent versions of Elixir.  May break usage w/ Elixir v1.2.  At this point, I'm guessing that 99.99% of people are using v1.3 or newer.